### PR TITLE
Check windows GPU build with latest nvcc activation scripts

### DIFF
--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -10,6 +10,11 @@ echo cli is %cli%, gui is %gui% and gpu is %gpu%
 
 echo CUDA_HOME: %CUDA_HOME%
 echo CUDA_PATH: %CUDA_PATH%
+echo INCLUDE: %INCLUDE%
+
+echo CXXFLAGS (before): %CXXFLAGS% 
+set "CXXFLAGS="
+echo CXXFLAGS (after): %CXXFLAGS% 
 
 set MENU_DIR=%PREFIX%\Menu
 if not exist %MENU_DIR% mkdir %MENU_DIR%

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -11,10 +11,6 @@ echo cli is %cli%, gui is %gui% and gpu is %gpu%
 echo CUDA_HOME: %CUDA_HOME%
 echo CUDA_PATH: %CUDA_PATH%
 
-set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%cuda_compiler_version%"
-
-echo CUDA_PATH (after): %CUDA_PATH%
-
 set MENU_DIR=%PREFIX%\Menu
 if not exist %MENU_DIR% mkdir %MENU_DIR%
 

--- a/recipe/build_pyprismatic.bat
+++ b/recipe/build_pyprismatic.bat
@@ -6,10 +6,6 @@ set "CMAKE_GENERATOR=NMake Makefiles"
 echo CUDA_HOME: %CUDA_HOME%
 echo CUDA_PATH: %CUDA_PATH%
 
-set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%cuda_compiler_version%"
-
-echo CUDA_PATH (after): %CUDA_PATH%
-
 if "%cuda_compiler_version%" == "None" (
 	%PYTHON% setup.py build_ext ^
 			-DHDF5_DIR=%LIBRARY_PREFIX%\cmake\hdf5 ^


### PR DESCRIPTION
This PR is to check the latest change (https://github.com/conda-forge/nvcc-feedstock/pull/52 and https://github.com/conda-forge/nvcc-feedstock/pull/57) in the nvcc activation scripts:
- it is not necessary to set `%CUDA_PATH%` in the build script (https://github.com/conda-forge/nvcc-feedstock/issues/53 seems to be fixed).
